### PR TITLE
windowCovering opposite pin stop feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ When operating, the GPIO is turned on for 200ms to simulate a button pression on
 | `inverted`               	 | Boolean			| false		| optional, reverse the behaviour of the GPIO **output** pin(s) (pulse becomes HIGH->LOW->HIGH)																						|
 | `initPosition`			 | Integer (%)		| 0			| optional, default shutter position at homebridge startup to compensate absence of state feedback, recommanded to ensure open/close scenarios after unexptected restart: 99% |
 | `shiftDuration`            | Integer (sec)	| 20		| optional, duration of a shift (close->open or open->close) used to compute intermediate position																		|
-| `pulseDuration`          	 | Integer			| 200		| optional, duration of the pin pulse. (0: deactivate, pin active during all shifting)																					|
+| `pulseDuration`          	 | Integer			| 200		| optional, duration of the pin pulse. (0: deactivate, pin active during all shifting)	
+| `invertStopPin`          	 | Boolean			| false		| optional, utilize the opposite pin to stop the shutter |
 | `openSensorPin`            | Integer			| N/A		| optional, input pin number for open sensor (LOW: opened position)																												|
 | `closeSensorPin`           | Integer			| N/A		| optional, input pin number for close sensor (LOW: closed position)																												|
 | `invertedInputs`         	 | Boolean			| false		| optional, reverse the behaviour of the GPIO **input** pins (detect opened/closed on HIGH state)																				|

--- a/index.js
+++ b/index.js
@@ -406,6 +406,7 @@ function RollerShutter(accesory, log, config) {
 	this.restoreTarget = config.restoreTarget || false;
 	this.shiftDuration = (config.shiftDuration || 20) * 10; // Shift duration in ms for a move of 1%
 	this.pulseDuration = config.pulseDuration !== undefined ? config.pulseDuration : 200;
+	this.invertStopPin = config.invertStopPin || false; 
 	this.openSensorPin = config.openSensorPin !== undefined ? config.openSensorPin : null;
 	this.closeSensorPin = config.closeSensorPin !== undefined ? config.closeSensorPin : null;
 	this.invertedInputs = config.invertedInputs || false;
@@ -511,11 +512,15 @@ RollerShutter.prototype = {
 	
 	motionEnd: function() {
 		if(this.shift.target < 100 && this.shift.target > 0) {
-			//this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
-			var pin = this.shift.value > 0 ? this.closePin : this.openPin;
-			wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
-			wpi.delay(this.pulseDuration);
-			wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
+			if(this.invertStopPin = false) {
+				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
+			} else { 
+				// stop shutter by pulsing the opposite pin
+				var pin = this.shift.value > 0 ? this.closePin : this.openPin;
+				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
+				wpi.delay(this.pulseDuration);
+				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
+			}
 		}
 		
 		if(this.restoreTarget) {

--- a/index.js
+++ b/index.js
@@ -511,7 +511,11 @@ RollerShutter.prototype = {
 	
 	motionEnd: function() {
 		if(this.shift.target < 100 && this.shift.target > 0) {
-			this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
+			//this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
+			var pin = this.shift.value > 0 ? this.closePin : this.openPin;
+			wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
+			wpi.delay(this.pulseDuration);
+			wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
 		}
 		
 		if(this.restoreTarget) {

--- a/index.js
+++ b/index.js
@@ -518,7 +518,7 @@ RollerShutter.prototype = {
 				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
 				wpi.delay(this.pulseDuration);
 				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
-				this.log("Using opposite pin: "+pin+" to stop motion");
+				this.log("Using opposite pin, "+pin+" to stop motion");
 			} else { 
 				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
 			}

--- a/index.js
+++ b/index.js
@@ -406,7 +406,6 @@ function RollerShutter(accesory, log, config) {
 	this.restoreTarget = config.restoreTarget || false;
 	this.shiftDuration = (config.shiftDuration || 20) * 10; // Shift duration in ms for a move of 1%
 	this.pulseDuration = config.pulseDuration !== undefined ? config.pulseDuration : 200;
-	this.invertStopPin = config.invertStopPin || false; 
 	this.openSensorPin = config.openSensorPin !== undefined ? config.openSensorPin : null;
 	this.closeSensorPin = config.closeSensorPin !== undefined ? config.closeSensorPin : null;
 	this.invertedInputs = config.invertedInputs || false;
@@ -512,15 +511,11 @@ RollerShutter.prototype = {
 	
 	motionEnd: function() {
 		if(this.shift.target < 100 && this.shift.target > 0) {
-			if(this.invertStopPin = false) {
-				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
-			} else { 
-				// stop shutter by pulsing the opposite pin
-				var pin = this.shift.value > 0 ? this.closePin : this.openPin;
-				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
-				wpi.delay(this.pulseDuration);
-				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
-			}
+			//this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
+			var pin = this.shift.value > 0 ? this.closePin : this.openPin;
+			wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
+			wpi.delay(this.pulseDuration);
+			wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
 		}
 		
 		if(this.restoreTarget) {

--- a/index.js
+++ b/index.js
@@ -406,6 +406,7 @@ function RollerShutter(accesory, log, config) {
 	this.restoreTarget = config.restoreTarget || false;
 	this.shiftDuration = (config.shiftDuration || 20) * 10; // Shift duration in ms for a move of 1%
 	this.pulseDuration = config.pulseDuration !== undefined ? config.pulseDuration : 200;
+	this.invertStopPin = config.invertStopPin || false;
 	this.openSensorPin = config.openSensorPin !== undefined ? config.openSensorPin : null;
 	this.closeSensorPin = config.closeSensorPin !== undefined ? config.closeSensorPin : null;
 	this.invertedInputs = config.invertedInputs || false;
@@ -511,11 +512,15 @@ RollerShutter.prototype = {
 	
 	motionEnd: function() {
 		if(this.shift.target < 100 && this.shift.target > 0) {
-			//this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
-			var pin = this.shift.value > 0 ? this.closePin : this.openPin;
-			wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
-			wpi.delay(this.pulseDuration);
-			wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
+			if(this.invertStopPin) {
+				// stop shutter by pulsing the opposite pin
+				var pin = this.shift.value > 0 ? this.closePin : this.openPin;
+				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
+				wpi.delay(this.pulseDuration);
+				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
+			} else { 
+				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
+			}
 		}
 		
 		if(this.restoreTarget) {

--- a/index.js
+++ b/index.js
@@ -512,12 +512,13 @@ RollerShutter.prototype = {
 	
 	motionEnd: function() {
 		if(this.shift.target < 100 && this.shift.target > 0) {
-			if(this.invertStopPin) {
+			if(this.invertStopPin === true) {
 				// stop shutter by pulsing the opposite pin
 				var pin = this.shift.value > 0 ? this.closePin : this.openPin;
 				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
 				wpi.delay(this.pulseDuration);
 				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
+				this.log("Using opposite pin: "+pin+" to stop motion");
 			} else { 
 				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
 			}

--- a/index.js
+++ b/index.js
@@ -518,7 +518,7 @@ RollerShutter.prototype = {
 				wpi.digitalWrite(pin, this.OUTPUT_ACTIVE);
 				wpi.delay(this.pulseDuration);
 				wpi.digitalWrite(pin, this.OUTPUT_INACTIVE);
-				this.log("Using opposite pin, "+pin+" to stop motion");
+				this.log("Pulse pin "+pin+" to stop motion");
 			} else { 
 				this.pinPulse(this.shift.value, false); // Stop shutter by pulsing same pin another time
 			}


### PR DESCRIPTION
Adds logic, config, and readme for an optional windowCovering feature to pulse the opposite pin to stop the motion of the shutter, rather than a second pulse of the same pin. Defaults false.