### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Configuration example:
 }
 ```
 
-`pin` numbers must be specified as wPi pin number in the `Pin Configuration` table below
+`pin` numbers must be specified as ~~wPi~~ **BCM** (as of v0.4.7) pin number in the `Pin Configuration` table below
 
 ## Common configuration
 


### PR DESCRIPTION
Update documentation stating BCM instead of wPi pins. This is serious because it can cause ethernet connection loss https://github.com/dubocr/homebridge-gpio-device/issues/106