### PR TITLE
changing DigitalInput toggle to stateChange

### DIFF
--- a/index.js
+++ b/index.js
@@ -214,7 +214,7 @@ function DigitalInput(accesory, log, config) {
 			this.pin,
 			gpio.INPUT,
 			gpio.INT_EDGE_BOTH,
-			this.toggleState.bind(this),
+			this.stateChange.bind(this),
 			this.pullUp ? gpio.PULL_UP : gpio.PULL_OFF
 		);
 	}


### PR DESCRIPTION
i can't speak for anything other than the MotionSensor with OccupancySensor, but it looks like the second gpio.init() call should be stateChange rather than toggle callback in order to trigger the occupancy sensor update call.
I believe this resolves #121